### PR TITLE
Add fallback handling for GitHub stats widget

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1226,6 +1226,33 @@ body {
   transform: translateY(-4px);
 }
 
+.github-stat-fallback {
+  width: 100%;
+  max-width: 100%;
+  padding: var(--spacing-md);
+  background: var(--surface-secondary);
+  border-radius: 0.5rem;
+  border: 1px dashed var(--border-color);
+  color: var(--text-secondary);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+}
+
+.github-fallback-link {
+  color: var(--accent-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.github-fallback-link:hover {
+  text-decoration: underline;
+}
+
 .github-cta {
   text-align: center;
   margin-top: var(--spacing-lg);

--- a/src/components/GitHub.jsx
+++ b/src/components/GitHub.jsx
@@ -1,8 +1,33 @@
+import { useMemo, useState } from 'react'
 import { FaGithub, FaStar, FaCodeBranch } from 'react-icons/fa'
 
 function GitHub() {
   const githubUsername = 'cjlludwig'
   const githubUrl = `https://github.com/${githubUsername}`
+
+  const statsUrl = useMemo(
+    () =>
+      `https://github-readme-stats.vercel.app/api?username=${githubUsername}&show_icons=true&theme=tokyonight&hide_border=true&bg_color=1e293b&title_color=3b82f6&icon_color=3b82f6&text_color=cbd5e1&hide_rank=true&cache_seconds=21600`,
+    [githubUsername]
+  )
+
+  const languagesUrl = useMemo(
+    () =>
+      `https://github-readme-stats.vercel.app/api/top-langs/?username=${githubUsername}&layout=compact&theme=tokyonight&hide_border=true&bg_color=1e293b&title_color=3b82f6&text_color=cbd5e1&card_width=300&cache_seconds=21600`,
+    [githubUsername]
+  )
+
+  const [statsUnavailable, setStatsUnavailable] = useState(false)
+  const [languagesUnavailable, setLanguagesUnavailable] = useState(false)
+
+  const renderFallback = (title, href) => (
+    <div className="github-stat-fallback">
+      <p>{title} are temporarily unavailable.</p>
+      <a href={href} target="_blank" rel="noopener noreferrer" className="github-fallback-link">
+        Open on GitHub
+      </a>
+    </div>
+  )
 
   return (
     <section className="section github">
@@ -36,19 +61,33 @@ function GitHub() {
           {/* Compact Stats Grid */}
           <div className="github-stats-grid">
             <div className="github-stat-item">
-              <img
-                src={`https://github-readme-stats.vercel.app/api?username=${githubUsername}&show_icons=true&theme=tokyonight&hide_border=true&bg_color=1e293b&title_color=3b82f6&icon_color=3b82f6&text_color=cbd5e1&hide_rank=true`}
-                alt="GitHub Stats"
-                className="github-stat-card"
-              />
+              {statsUnavailable ? (
+                renderFallback('GitHub stats', statsUrl)
+              ) : (
+                <img
+                  src={statsUrl}
+                  alt="GitHub Stats"
+                  className="github-stat-card"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                  onError={() => setStatsUnavailable(true)}
+                />
+              )}
             </div>
-            
+
             <div className="github-stat-item">
-              <img
-                src={`https://github-readme-stats.vercel.app/api/top-langs/?username=${githubUsername}&layout=compact&theme=tokyonight&hide_border=true&bg_color=1e293b&title_color=3b82f6&text_color=cbd5e1&card_width=300`}
-                alt="Top Languages"
-                className="github-stat-card"
-              />
+              {languagesUnavailable ? (
+                renderFallback('Top languages', languagesUrl)
+              ) : (
+                <img
+                  src={languagesUrl}
+                  alt="Top Languages"
+                  className="github-stat-card"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                  onError={() => setLanguagesUnavailable(true)}
+                />
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- memoize GitHub stats image URLs with longer cache duration and lazy loading
- add error handling with fallback call-to-action links when the widgets fail to load
- style the fallback state to fit the existing GitHub stats grid

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930bd92e078832a8975ef1651f51c90)