### PR TITLE
Fix blog markdown spacing and mermaid rendering

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -279,6 +279,22 @@ body {
   color: var(--text-primary);
 }
 
+.blog-post-body ul,
+.blog-post-body ol {
+  margin: var(--spacing-sm) 0 var(--spacing-md);
+  padding-left: 1.25rem;
+  color: var(--text-secondary);
+}
+
+.blog-post-body li {
+  margin-bottom: 0.35rem;
+}
+
+.blog-post-body ul ul,
+.blog-post-body ol ol {
+  margin: 0.35rem 0;
+}
+
 .blog-post-body pre,
 .blog-post-body code {
   font-family: var(--font-mono);
@@ -316,6 +332,7 @@ body {
   border-radius: 0.75rem;
   padding: var(--spacing-md);
   border: 1px solid var(--border-color);
+  overflow-x: auto;
 }
 
 /* Hero Section */

--- a/src/components/BlogPost.jsx
+++ b/src/components/BlogPost.jsx
@@ -7,6 +7,16 @@ function BlogPost({ post }) {
   useEffect(() => {
     if (!post || !contentRef.current) return
 
+    // Convert fenced mermaid code blocks into mermaid containers
+    const mermaidCodeBlocks = contentRef.current.querySelectorAll('pre code.language-mermaid')
+    mermaidCodeBlocks.forEach((codeBlock) => {
+      const pre = codeBlock.parentElement
+      const container = document.createElement('div')
+      container.className = 'mermaid'
+      container.textContent = codeBlock.textContent
+      pre.replaceWith(container)
+    })
+
     const mermaidBlocks = contentRef.current.querySelectorAll('.mermaid')
     if (mermaidBlocks.length) {
       mermaid.initialize({ startOnLoad: false, theme: 'neutral' })


### PR DESCRIPTION
## Summary
- Improve blog post markdown styling by adding list spacing and padding for better readability on mobile
- Convert fenced mermaid code blocks into mermaid containers and allow diagrams to scroll horizontally

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931da888f34832aab8aaba676ebad58)