### PR TITLE
Upgrade to Node 22

### DIFF
--- a/.github/workflows/deploy-page.yml
+++ b/.github/workflows/deploy-page.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
           
       - name: Install dependencies

--- a/.github/workflows/validate-commit.yml
+++ b/.github/workflows/validate-commit.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/docs/VALIDATION_GUIDE.md
+++ b/docs/VALIDATION_GUIDE.md
@@ -243,7 +243,7 @@ Add to your README to show build status:
 **Solution:**
 ```bash
 # Check Node version matches CI
-node --version  # Should be 18.x
+node --version  # Should be 22.x
 
 # Ensure all files are committed
 git status

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "Connor Ludwig",
   "type": "module",
   "homepage": "https://cjlludwig.github.io",
+  "engines": {
+    "node": "^22.0.0"
+  },
   "scripts": {
     "parse-resume": "node scripts/parse-resume.js",
     "generate-blogs": "node scripts/generate-blogs.js",


### PR DESCRIPTION
## Summary
- enforce Node 22 in package engines metadata
- update GitHub Actions workflows to use Node 22 with current action versions
- refresh validation documentation to reference Node 22

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693232f8002c832aa583df297fd69d47)