### PR TITLE
Streamline mobile navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -110,11 +110,15 @@ body {
   align-items: center;
 }
 
-.nav-links a {
+.nav-links a { 
   color: var(--text-secondary);
   text-decoration: none;
   font-weight: 500;
   transition: color 0.2s ease;
+}
+
+.nav-blog {
+  font-weight: 600;
 }
 
 .nav-links a:hover {
@@ -1462,19 +1466,24 @@ body {
     gap: var(--spacing-sm);
   }
 
-  /* Hide professional links on mobile, keep fun ones */
-  .nav-links a:not(.nav-fun):not(.theme-toggle) {
+  /* Hide professional links on mobile, keep blog and fun links */
+  .nav-links a:not(.nav-fun):not(.nav-blog):not(.theme-toggle) {
     display: none;
   }
-  
+
   /* Show fun links on mobile */
   .nav-links .nav-fun {
     display: inline-block;
   }
-  
-  /* Keep separator visible to show fun section */
+
+  /* Keep the blog link visible on mobile */
+  .nav-links .nav-blog {
+    display: inline-block;
+  }
+
+  /* Hide separator on mobile for a cleaner layout */
   .nav-separator {
-    display: inline;
+    display: none;
   }
   
   /* Reduce spacing on mobile */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -165,11 +165,13 @@ function App() {
               <a href="#experience">Experience</a>
               <a href="#skills">Skills</a>
               <a href="#projects">Projects</a>
-              <a href="#/blog">Blog</a>
+              <a href="#/blog" className="nav-blog">
+                Blog
+              </a>
               <span className="nav-separator">|</span>
-              <a href="#books" className="nav-fun">Books</a>
-              <a href="#movies" className="nav-fun">Movies</a>
-              <a href="#music" className="nav-fun">Music</a>
+              <a href="#books" className="nav-fun">
+                Fun Stuff
+              </a>
               <button 
                 onClick={toggleDarkMode} 
                 className="theme-toggle"

--- a/src/components/BlogIndex.jsx
+++ b/src/components/BlogIndex.jsx
@@ -3,7 +3,6 @@ function BlogIndex({ posts }) {
     <section className="section" id="blog">
       <div className="container">
         <div className="section-header">
-          <p className="section-subtitle">Writing</p>
           <h2 className="section-title">Latest Posts</h2>
           <p className="section-description">
             Notes on engineering, architecture experiments, and the tools I enjoy using.


### PR DESCRIPTION
## Summary
- ensure the blog link stays visible on mobile and merge entertainment links into a single "Fun Stuff" entry pointing to books
- tweak mobile navigation styles for the updated links
- remove the misaligned "Writing" subtitle from the blog index header

## Testing
- Not run (npm command unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933156db3b8832a9c866734236fa679)